### PR TITLE
Update TSC members

### DIFF
--- a/governance/tsc/README.md
+++ b/governance/tsc/README.md
@@ -10,34 +10,41 @@ Current members:
 - [Anthony Ramine](https://github.com/nox)
 - [Connor Brewster](https://github.com/cbrewster)
 - [Cheng-You Bai](https://github.com/cybai)
+- [Delan Azabani](https://github.com/delan)
 - [Diane Hosfelt](https://github.com/avadacatavra)
-- [Dzmitry Malyshau](https://github.com/kvark)
 - [Emilio Cobos Álvarez](https://github.com/emilio)
 - [Fernando Jiménez Moreno](https://github.com/ferjm)
 - [Gregory Terzian](https://github.com/gterzian)
 - [Jack Moffitt](https://github.com/metajack)
 - [James Graham](https://github.com/jgraham)
+- [Josh Aas](https://github.com/bdaehlie)
 - [Josh Matthews](https://github.com/jdm) (secretary)
 - [Keith Yeung](https://github.com/KiChjang)
+- [Manuel Rego](https://github.com/mrego)
 - [Manish Goregaokar](https://github.com/Manishearth)
 - [Martin Robinson](https://github.com/mrobinson)
+- [Oriol Brufau](https://github.com/Loirooriol)
 - [Patrick Walton](https://github.com/pcwalton)
+- [Philip Lamb](https://github.com/philip-lamb)
 - [Paul Rouget](https://github.com/paulrouget)
 - [Simon Sapin](https://github.com/SimonSapin)
 
 Past members:
 
+- [Dzmitry Malyshau](https://github.com/kvark)
 - [Lars Bergstrom](https://github.com/larsbergstrom)
 
 ## Meetings
 
 The TSC meets in public, and all minutes are published.
 
+* [10 Dec 2021](tsc-2021-12-10.md)
+* [08 Oct 2021](tsc-2021-10-08.md)
 * [11 Jun 2021](tsc-2021-06-11.md)
 * [09 Apr 2021](tsc-2021-04-09.md)
 * [12 Feb 2021](tsc-2021-02-12.md)
 * [11 Dec 2020](tsc-2020-12-11.md)
-* [9 Oct 2020](tsc-2020-10-09.md)
+* [09 Oct 2020](tsc-2020-10-09.md)
 
 Launch subcommittee meetings:
 * [20 Nov 2020](launch-2020-11-20.md)
@@ -56,9 +63,15 @@ Infrastructure subcommittee meetings:
 The TSC can form subcommittees for detailed discussion of issues.
 Contact the TSC secretary to join a subcommittee.
 
+Past subcommittees:
+
 - infrastructure
   - [Josh Matthews](https://github.com/jdm)
   - [Alan Jeffrey](https://github.com/asajeffrey)
+- launch
+  - [Alan Jeffrey](https://github.com/asajeffrey)
+  - [Lars Bergstrom](https://github.com/larsbergstrom)
+  - [Simon Sapin](https://github.com/SimonSapin)
 - technical direction
   - [Josh Matthews](https://github.com/jdm)
   - [Cheng-You Bai](https://github.com/cybai)
@@ -66,9 +79,3 @@ Contact the TSC secretary to join a subcommittee.
   - [Martin Robinson](https://github.com/mrobinson)
   - [Manish Goregaokar](https://github.com/Manishearth)
 
-Past subcommittees:
-
-- launch
-  - [Alan Jeffrey](https://github.com/asajeffrey)
-  - [Lars Bergstrom](https://github.com/larsbergstrom)
-  - [Simon Sapin](https://github.com/SimonSapin)


### PR DESCRIPTION
This patch updates the list of TSC members.
It also add links to the TSC meeting minutes on the repository that were not linked yet in the README file.
Last, it moves the subcommittees to "Past subcommittees" as they are no longer active.

@jdm this updates the list of TSC members, I'll do a different PR to add the minutes of the TSC meeting held on Dec 12th and reflect the chair change.