### PR TITLE
Add minutes for TSC February 2023 call (fix #56)

### DIFF
--- a/governance/tsc/tsc-2023-02-20.md
+++ b/governance/tsc/tsc-2023-02-20.md
@@ -1,0 +1,72 @@
+# Servo Technical Steering Committee Meeting
+
+* Date: [Monday 20th February 2023 at 16:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Servo%20TSC%20Meeting%20February%202023%20(2023-02-20)&iso=20230220T1600)
+* Location: Jitsi
+
+## Agenda
+
+* Status update
+* Review policy about how to add contributors to Servo libraries: https://servo.org/contributing/#collaborators
+* Support for ipfs:// and ipns:// protocols: https://github.com/servo/servo/discussions/29332
+* Linux Foundation
+* Outreach
+* AOB
+
+## Notes
+
+attending: asajeffrey, cybai, jdm, Loirooriol, mrego, mrobinson
+
+### Status update
+
+mrego: Time to start the meeting. Thank you for joining. We will be taking minutes in this stream during the meeting and then we will publish them later in the GitHub repository as usual. We have the agenda here and we can add more points later.
+
+The first point is the status update. We have been updating the Servo website and integrating the downloads page and blog sections. The structure and contents are a little different now. If you see any issues, just file and we can update it.
+
+mrobinson: Following the plan discussed on the previous meeting.
+
+in general this is almost done
+
+we have a new intermittent dashboard that tracks failures for each run
+
+the goal is that flaky tests don't block unrelated changes
+
+we're pretty close, we need to find the balance between ignoring and not ignoring things
+
+we could be probably announcing the dashboard soon
+
+### Review policy about how to add contributors to Servo libraries: https://servo.org/contributing/#collaborators
+
+mrego: the next point is reviewing the policy for adding contributors. The link above is the current policy. We need to decide how to grant people permissions.
+
+This will apply for Servo and for other servo-project repositories on GitHub.
+
+### Support for ipfs:// and ipns:// protocols: https://github.com/servo/servo/discussions/29332
+
+mrego: This discussion is just to bring awareness on this topic to the TSC. This was a request asking if Servo should support these protocols related to the distributed web. Josh was wondering what the usecases and maintenance burden would be like. The discussion also could expand to include ideas about adding general extension points for new protocols. Any other comments or feedback about this.
+
+Fabrice Desré: we kind of concluded that this could be added to the embedder api
+
+jdm: I like how the discussion has moved to a more general purpose. Having examples of researchers adding these extension in demos, etc is positive.
+
+jdm: I like the idea of exposing this functionality to embedders, not just making it part of the core project. It would be nice to have more small embedding samples that show how to do this.
+
+### Linux Foundation
+
+A quick update about this. I finally managed to talk to Todd, the LF representative. There are no members on the LF board from Servo, so we have no representation there. The project is a regular LF community project at this stage. If there are organizations that want to members, the board will be set up. In the meantime, the TSC leads direction of the project.
+
+jdm: Just to be clear, switching the formal status of the project to having no corporate sponsors, would make it very hard to use the funds we have in reserve except for one-off expenses.
+
+mrego: I asked about that money and since there is no board right now, the companies that gave that money would have to decide how to spend that money.
+
+### Outreach
+
+mrego: I'm not sure about the details of all the plans around this, but we have done a few things such a blog posts and reactivating twitter, etc. As the project evolves, we'll try to give more talks, etc. Not a lot of updates regarding this ATM.
+
+### AOB
+
+mrego: One open question about the roadmap from cybai.
+
+we published this blog post: https://servo.org/blog/2023/02/03/servo-2023-roadmap/
+
+mrego: No more questions. Thank you for your time today.
+

--- a/governance/tsc/tsc-2023-02-20.md
+++ b/governance/tsc/tsc-2023-02-20.md
@@ -46,8 +46,6 @@ mrego: This discussion is just to bring awareness on this topic to the TSC. This
 
 Fabrice Desré: we kind of concluded that this could be added to the embedder api
 
-jdm: I like how the discussion has moved to a more general purpose. Having examples of researchers adding these extension in demos, etc is positive.
-
 jdm: I like the idea of exposing this functionality to embedders, not just making it part of the core project. It would be nice to have more small embedding samples that show how to do this.
 
 ### Linux Foundation


### PR DESCRIPTION
The live minutes are extracted from the Zulip topic: https://servo.zulipchat.com/#narrow/stream/263398-general/topic/TSC.20Meeting.20February.202023