### PR TITLE
Add minutes for TSC March 2023 call (fix #58)

### DIFF
--- a/governance/tsc/tsc-2023-03-20.md
+++ b/governance/tsc/tsc-2023-03-20.md
@@ -1,0 +1,121 @@
+# Servo Technical Steering Committee Meeting
+
+* Date: [Monday 20th March 2023 at 16:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Servo%20TSC%20Meeting%20March%202023%20(2023-03-20)&iso=20230320T1600)
+* Location: jitsi
+
+## Agenda
+
+* Status update
+* Layout engine
+* Criteria for merging dependabot PRs
+* Demos ideas
+* Linux Foundation
+* Outreach
+* AOB
+
+## Notes
+
+attending: asajeffrey, jdm, Loirooriol, mrego, mrobinson
+
+### Status update
+
+rego: We are starting the meeting. Taking notes in the Zulip channel. First topic is the status update.
+
+rego: https://servo.org/blog/2023/03/16/making-easier-to-contribute/
+
+rego: One important thing we have been working on, for which we've published a blogpost, is the intermittent tracking and the intermittent dashboard. This is for speeding up the CI. The blogpost has more details.
+
+rego: https://servo.github.io/internal-wpt-dashboard/
+
+rego: We've also been setting up an internal dashboard to track progress on WPT tests, CSS2 the focus area for this year. Currently, the dashboard only shows results for the default layout engine (2013), but we are looking into adding the same data for layout 2020 so that we can compare and track the progress of both engines.
+
+rego: Otherwise, we have been looking at upgrading WebRender, which requires moving scrolling bits into Servo. Once that is done, we should be able to update WebRender. We've also been looking at added the named window accesses, which should fix many WPT tests.
+
+### Layout engine
+
+rego: https://github.com/servo/servo/wiki/Layout-2020-vs-2013
+
+rego: The next point on the agenda is the layout engine. We were planning to send something earlier, but we don't have it yet. We've been analyzing them both and comparing their feature support with regard to basic CSS and HTML support. From what we have seen, the old engine has better support, but the new one makes it easier to add features due to following spec terminology. We still don't have a clear decision, but we are leaning toward layout 2020. Before doing a proper selection, we want to experiment a bit by adding a few small features in the next few weeks in order to have a proper analysis of the state of things and a final proposal for the TSC.
+
+### Criteria for merging dependabot PRs
+
+rego: The next topic is mostly a question for jdm. Sometimes they are accepted, sometimes they are closed.
+
+jdm: There's no criteria written, but if its a core engine feature, I'll go ahead and merge it. If the change notes include safety fixes, I'll try to include those. Otherwise, if it's not a direct dependency or for a platform we don't really care about or adding a feature that's not necessary for us to compile, I won't merge those. The other thing I also consider is that the CI will fail if there's any duplicate dependencies introduced in the new upgrades. If I'm not in the mood to go ahead and remove duplicates and it's not a safety fix, I'll go ahead and close it.
+
+rego: Now we know the criteria.
+
+martin: about dependabot how often it suggests upgrades
+
+jdm: There is a daily process and you can configure the time, but I haven't looked into that.
+
+rego: Thank you for the information.
+
+### Demos ideas
+
+rego: We are thinking about what kinds of demos we could make to show off the project. Perhaps people here have some ideas about what kind of demos we could make to attract more people to the project.
+
+jdm: There was a repository of demos to run: https://mozdevs.github.io/servo-experiments/
+
+alan: Do we know what the current state of browser.html is?
+
+jdm: I don't think anyone has touched it in years.
+
+alan: Does that mean we'd have to go through and write all the chrome via native toolkits.
+
+jdm: I think we ripped out the moz browser stuff a long time ago.
+
+rego: browser.html is an experimental browser in html?
+
+rego: https://github.com/browserhtml/browserhtml
+
+jdm: the first servo demo was this thing that loaded a browser based on servo that rendered all chrome via HTML and JavaScript.
+
+Fabrice Desré: Yes the <iframe mozbrowser> code was removed. I'd still like to have a <web-view> like web component to replace that. At the time Paul who was leading the embedding efforts had different ideas about the chrome vs content barrier
+
+### Linux Foundation
+
+rego: We finally managed to move payments to Igalia from Alan's credit card. We haven't managed everything with reimbursements yet. We have noticed that the last invoice was bigger probably due to new activity and bots downloading the binaries. We are looking to move those somewhere else. In regard to Servo budget from LF, we are looking to see if we can use that this year.
+
+### Outreach
+
+rego: Let's see if we can retake work on demos in the next quarter.
+
+rego: Regarding events, we are looking at attending some LF events. We have worked on submitting some talks, but let's see if they are accepted.
+
+### AOB
+
+martin: I want to raise a point about WPT imports
+
+martin: one thing is generate results for Layout 2020, making small changes to the scripts to do that
+
+martin: the other thing is about how often import happens
+
+martin: maybe we can do it once a week or twice a week, so we can adjust expectations and handle some of the flakes differently
+
+jdm: I have an argument against that, now that we have the thing that checks results; why it's taking too long to merge things?
+
+martin: maybe just people clicking the buttons
+
+jdm: maybe the comment to merge PRs is added before homu has actually started
+
+martin: another problem is try to detect flakes during imports, or there are some tests that are completely unstable
+
+martin: maybe some of those need to be skip
+
+jdm: that's a problem we've been aware, I have no objects to slowing down to once/twice a week to make the process more manageable
+
+martin: if you cannot generate stable results, have the chance to have flaky expectations
+
+alan: do we know which organizations are contributing to WPT theses days
+
+martin: all browser engines: chromium, firefox and webkit developers
+
+alan: so mozilla and apple are still sending patches, I was worried if it was just google
+
+martin: no, all of them are doing it now
+
+rego: I don't think we have any more topics, unless folks have other questions.
+
+rego: Thanks you everyone for joining us today.
+


### PR DESCRIPTION
The live minutes are extracted from the Zulip topic: https://servo.zulipchat.com/#narrow/stream/263398-general/topic/TSC.20Meeting.20March.202023