### PR TITLE
Improvements to funding requests document

### DIFF
--- a/FUNDING_REQUEST.md
+++ b/FUNDING_REQUEST.md
@@ -29,7 +29,17 @@ Examples of appropriate funding requests include:
 * grant for implementing a specific feature
 * paid work on recurring project activities
 
-# Funding logistics
+## Funding timelines
+
+Recurring funding requests will have the following conditions:
+* Trial period (3 months): After 3 months, the people behind the funding request should do a brief report on the highlights during the initial 3 months. The TSC would decide if we continue or stop the funding request.
+* Re-evaluation (after 12 months): All funding requests expire after 1 year. They can be renewed by requesting a continuation and getting approval by the TSC.
+
+## Funding cancellation
+
+If the financial situation of the Servo project changes significantly, the TSC might decide to stop any of the ongoing funding requests.
+
+## Funding logistics
 
 All approved funding requests will be paid through [Open Collective](https://opencollective.com/servo), which provides an [FAQ](https://docs.opencollective.com/oceurope/how-it-works/expenses/expenses-and-getting-paid-faqs).
 


### PR DESCRIPTION
This setups a 3 months trial period and a 1 year re-evaluation for recurring funding requests.

It also adds a clause that if the Servo funding situation changes, funding requests can be cancelled by the TSC.

For context this has been discussed in Zulip:
* [#tsc > ✔ Evaluation period for recurring expenses](https://servo.zulipchat.com/#narrow/channel/500774-tsc/topic/.E2.9C.94.20Evaluation.20period.20for.20recurring.20expenses/with/573248047)
* [#tsc > ✔ Evaluation period for recurring expenses](https://servo.zulipchat.com/#narrow/channel/500774-tsc/topic/.E2.9C.94.20Evaluation.20period.20for.20recurring.20expenses/with/573248047)

Both discussions are now merged at:
* [#tsc > Improvements to funding requests documentation](https://servo.zulipchat.com/#narrow/channel/500774-tsc/topic/Improvements.20to.20funding.20requests.20documentation/with/573245277)

We also briefly mentioned it on the last TSC call: https://github.com/servo/project/blob/main/governance/tsc/tsc-2026-01-26.md#time-limit-for-funding-requests