### PR TITLE
Mark Simon Wülker as unaffiliated in TSC member list

### DIFF
--- a/governance/TSC-MEMBERS.md
+++ b/governance/TSC-MEMBERS.md
@@ -15,7 +15,7 @@
 - [Rakhi Sharma (@atbrakhi)](https://github.com/atbrakhi) - Igalia
 - [Samson (@sagudev)](https://github.com/sagudev) - unaffiliated
 - [Simon Sapin (@SimonSapin)](https://github.com/SimonSapin) - unaffiliated
-- [Simon Wülker (@simonwuelker)](https://github.com/simonwuelker)
+- [Simon Wülker (@simonwuelker)](https://github.com/simonwuelker) - unaffiliated
 - [Taym Haddadi (@Taym95)](https://github.com/Taym95) - unaffiliated
 - [Wu Yu Wei (@wusyong)](https://github.com/wusyong) - unaffiliated
 


### PR DESCRIPTION
All other members disclose who they are affiliated with, let's do that for me too.